### PR TITLE
fix: Prevent TypeError for undefined controls in animate loop

### DIFF
--- a/index.html
+++ b/index.html
@@ -1093,7 +1093,7 @@
                 }
             }
 
-            if (controls.isLocked === true) {
+            if (controls && controls.isLocked === true) { // Added null check for controls
                 const time = performance.now();
                 const deltaMove = (time - prevTime) / 1000;
 


### PR DESCRIPTION
Corrected an issue where `animate()` could attempt to access `controls.isLocked` before the `controls` object was initialized. This occurred due to `animate()` being called immediately, while `controls` initialization happened later within `init()` (a callback for asset loading).

The fix involves adding a guard condition `if (controls && controls.isLocked === true)` to ensure `controls.isLocked` is only accessed if `controls` is defined, preventing the TypeError and allowing the game to load correctly.