### PR TITLE
Fix: Ensure composer is initialized before rendering

### DIFF
--- a/index.html
+++ b/index.html
@@ -217,7 +217,6 @@
 
         // Inicialização
         loadGameAssets(init);
-        animate();
 
         function loadGameAssets(callback) {
             let assetsLoaded = 0;
@@ -448,6 +447,7 @@
                 createEnemies();
                 // console.log("Inicialização completa."); // Removed
             }
+            animate();
         }
 
         function createSkybox() {


### PR DESCRIPTION
I moved the initial call to the animate() function to the end of finalizeInit(). This ensures that all Three.js components, including the EffectComposer (composer), are fully initialized before the rendering loop begins.

This resolves a TypeError that occurred when composer.render() was called before composer was assigned, due to animate() being called before the asynchronous asset loading and initialization process had completed.